### PR TITLE
Update regions allowed for discovery

### DIFF
--- a/AWS Discovery/README.md
+++ b/AWS Discovery/README.md
@@ -6,6 +6,8 @@ This script gives the option to either configure regions to be excluded from dis
 
 By default, only AWS deployments that are in error will be updated.
 
+Once the allowed regions have been updated successfully, it may take up to 12 hours for the discovery process to complete.
+
 Requirements:
 -----
 - Python 3.8+

--- a/AWS Discovery/README.md
+++ b/AWS Discovery/README.md
@@ -2,8 +2,9 @@ This script is used to update AWS deployments to restrict regions used in the Al
 
 This script gives the option to either configure regions to be excluded from discovery or limit discovery to a specific set of included regions.
 * Use the exclude option if single regions are being explictly blocked in AWS.   This ensures that when AWS adds new regions, they are automatically discovered.
-* Use the include option where the available regions are being specified, like the Control Tower case, where additional regions being made available is done explicitly.
+* Use the include option where the available regions are being specified, like the Control Tower case, where additional regions being made available is done explicitly.   Include mode is selected by default
 
+By default, only AWS deployments that are in error will be updated.
 
 Requirements:
 Python 3.8+
@@ -14,12 +15,20 @@ Configure api keys for the cli usage:  [https://developer.alertlogic.com/cli/fir
 Get Alert Logic customer ID from the support page in the console: [https://console.account.alertlogic.com/#/support/home]
 
 Usage:
-setregions.py [CustomerID] [-i|-x] region1,region2,region3
-* -i  Include the specified regions
-* -x  Exclude the specified regions from discovery
-* Regions is a comma separated list
+setregions.py -c [CID] -r [region1,region2]
+Options:
+    -c [CID]:  Alert Logic customer ID - https://console.account.alertlogic.com/#/support/home
+    -r [list]:  Comma separated list of AWS regions
+    -i:  Only include specified regions in discovery
+    -x:  Exclude specified regions from discovery
+    -e:  Apply Discovery regions to all AWS deployments in error
+    -a:  Apply Discovery regions to all AWS deployments
+    -d [AWSID]:  Apply Discovery regions to all AWS deployments
+    -h:  This usage page
 
-The current version of this script will update the discovery scope on all AWS deployments currently in error.
+CID and Region list are required.    If no other options are specified,
+this script will default to AWS deployments in error and 'include' mode.
 
 Example:
-setregions.py 12345 -i us-east-1,us-east-2,us-west-3
+setregions.py -c 12345 -r us-east-1,us-east-2,us-west-3 -a -i
+    - Set discovery on all AWS deployments in Alert Logic account 12345 to only discover resources in us-east-1, us-east-2, and us-west-3

--- a/AWS Discovery/README.md
+++ b/AWS Discovery/README.md
@@ -7,28 +7,30 @@ This script gives the option to either configure regions to be excluded from dis
 By default, only AWS deployments that are in error will be updated.
 
 Requirements:
-Python 3.8+
-alertlogic-sdk-python
+-----
+- Python 3.8+
+- alertlogic-sdk-python
 
 Setup:
-Configure api keys for the cli usage:  [https://developer.alertlogic.com/cli/first-use.htm]
-Get Alert Logic customer ID from the support page in the console: [https://console.account.alertlogic.com/#/support/home]
+-----
+- Configure api keys for the cli usage:  <https://developer.alertlogic.com/cli/first-use.htm>
+- Get Alert Logic customer ID from the support page in the console: <https://console.account.alertlogic.com/#/support/home>
 
-Usage:
-setregions.py -c [CID] -r [region1,region2]
-Options:
-    -c [CID]:  Alert Logic customer ID - https://console.account.alertlogic.com/#/support/home
-    -r [list]:  Comma separated list of AWS regions
-    -i:  Only include specified regions in discovery
-    -x:  Exclude specified regions from discovery
-    -e:  Apply Discovery regions to all AWS deployments in error
-    -a:  Apply Discovery regions to all AWS deployments
-    -d [AWSID]:  Apply Discovery regions to all AWS deployments
-    -h:  This usage page
+Usage:  
+-----
+setregions.py -c [CID] -r [region1,region2]  
+Options:  
+-   -c [CID]:  Alert Logic customer ID - <https://console.account.alertlogic.com/#/support/home>
+-   -r [list]:  Comma separated list of AWS regions
+-   -i:  Only include specified regions in discovery
+-   -x:  Exclude specified regions from discovery
+-   -e:  Apply Discovery regions to all AWS deployments in error
+-   -a:  Apply Discovery regions to all AWS deployments
+-   -d [AWSID]:  Apply Discovery regions to all AWS deployments
+-   -h:  This usage page
 
-CID and Region list are required.    If no other options are specified,
-this script will default to AWS deployments in error and 'include' mode.
+CID and Region list are required.    If no other options are specified, this script will default to AWS deployments in error and 'include' mode.
 
-Example:
-setregions.py -c 12345 -r us-east-1,us-east-2,us-west-3 -a -i
+Example:  
+`setregions.py -c 12345 -r us-east-1,us-east-2,us-west-3 -a -i`  
     - Set discovery on all AWS deployments in Alert Logic account 12345 to only discover resources in us-east-1, us-east-2, and us-west-3

--- a/AWS Discovery/README.md
+++ b/AWS Discovery/README.md
@@ -1,0 +1,25 @@
+This script is used to update AWS deployments to restrict regions used in the Alert Logic discovery process.   This is needed in cases where there are Service Control Policies in place to restrict which AWS regions are accessible, which is common in environments using Control Tower.
+
+This script gives the option to either configure regions to be excluded from discovery or limit discovery to a specific set of included regions.
+* Use the exclude option if single regions are being explictly blocked in AWS.   This ensures that when AWS adds new regions, they are automatically discovered.
+* Use the include option where the available regions are being specified, like the Control Tower case, where additional regions being made available is done explicitly.
+
+
+Requirements:
+Python 3.8+
+alertlogic-sdk-python
+
+Setup:
+Configure api keys for the cli usage:  [https://developer.alertlogic.com/cli/first-use.htm]
+Get Alert Logic customer ID from the support page in the console: [https://console.account.alertlogic.com/#/support/home]
+
+Usage:
+setregions.py [CustomerID] [-i|-x] region1,region2,region3
+* -i  Include the specified regions
+* -x  Exclude the specified regions from discovery
+* Regions is a comma separated list
+
+The current version of this script will update the discovery scope on all AWS deployments currently in error.
+
+Example:
+setregions.py 12345 -i us-east-1,us-east-2,us-west-3

--- a/AWS Discovery/requirements.txt
+++ b/AWS Discovery/requirements.txt
@@ -1,0 +1,1 @@
+alertlogic-sdk-python

--- a/AWS Discovery/setregions.py
+++ b/AWS Discovery/setregions.py
@@ -1,0 +1,79 @@
+#!python
+
+# This script will update the discovery regions for all AWS
+# deployments on the specified Alert Logic CID that are currently
+# in error.
+
+import sys
+import almdrlib
+import time
+
+def usage():
+    print(f"{sys.argv[0]} usage:")
+    print(f"{sys.argv[0]} CID [-x|-i] us-east-1,us-east-2")
+    print(f"")
+    print(f"One of:")
+    print(f" -x - Exclude listed regions from discovery")
+    print(f" -i - Only include listed regions in discovery")
+    print(f"")
+    print(f"List of regions is comma separated")
+
+    sys.exit()
+
+def scopeFeature(regions, inc="include"):
+    feature = {}
+    reg = []
+    rlist = regions.split(',')
+    for r in rlist:
+        robj = {"type": "region", "name": r}
+        reg.append(robj)
+    feature['discovery'] = [{'scope': {inc: reg}}]
+    #print(f"{feature}")
+    return feature
+
+def getDeployments(cid):
+    depClient = almdrlib.client("deployments")
+    res = depClient.list_deployments(account_id=cid)
+    errors = []
+    for d in res.json():
+        if d['platform']['type'] == 'aws':
+            if d['status']['status'] == 'error':
+                errors.append(d)
+                #print("Deployment")
+                #print(f"{d}")
+                #print("")
+    return errors
+
+def updateDeployment(cid, dep, feature):
+    print(f"{dep['id']=}")
+    depClient = almdrlib.client("deployments")
+    res = depClient.update_deployment(account_id=cid,
+        deployment_id=dep['id'],
+        version=dep['version'], features=feature)
+    print(f"{res=}")
+    exit
+
+# Main logic
+# Check for correct number of arguments
+if len(sys.argv) != 4:
+    usage()
+
+cid = sys.argv[1]
+
+# Get the mode we will be using or print usage
+if sys.argv[2] == '-x':
+    mode='exclude'
+elif sys.argv[2] == '-i':
+    mode='include'
+else:
+    usage()
+
+feature = scopeFeature(sys.argv[3], mode)
+
+errDep = getDeployments(cid)
+
+print(f"AWS deployments in error {len(errDep)}")
+
+for d in errDep:
+    updateDeployment(cid, d, feature)
+    time.sleep(1)

--- a/AWS Discovery/setregions.py
+++ b/AWS Discovery/setregions.py
@@ -65,7 +65,7 @@ def getOptions():
     if not opts['cid'] or not opts['regions']:
         print("Both CID and region list are required")
         usage()
-    print (f"{opts=}")
+    # print (f"{opts=}")
     return opts
 
 # Create object w/ discovery scope feature for use in updating deployments
@@ -103,7 +103,12 @@ def updateDeployment(cid, dep, feature, client):
     res = client.update_deployment(account_id=cid,
         deployment_id=dep['id'],
         version=dep['version'], features=feature)
-    print(f"Deployment: {d['name']} - Result = {res}")
+    if res.status_code == 200:
+        print(f"Deployment: {d['name']}")
+        print(f"  - Result: Success")
+    else:
+        print(f"Deployment: {d['name']}")
+        print(f"  - Result: Error:  {res.text}")
     exit
 
 # Main logic


### PR DESCRIPTION
It is common, especially in Control Tower deployments, to use region restrictions in service control policies as part of the security posture.   By default, discovery happens across all regions, which causes discovery to run into permission errors when these SCPs are in place.    This allows discovery options to be configured to exclude specific regions or be restricted to only discovering specified regions.